### PR TITLE
fix(caddy): log to /var/log/caddy/orewire.ca.access.log

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -73,7 +73,7 @@ orewire.ca {
   }
 
   log {
-    output file /home/deployer/orewire-laravel/log/access.log {
+    output file /var/log/caddy/orewire.ca.access.log {
       mode 0644
     }
   }


### PR DESCRIPTION
Caddy access log path: use /var/log/caddy so deployer does not need sudo or log dir in deploy path.

Made with [Cursor](https://cursor.com)