### PR TITLE
feat: drill results factories and integration tests

### DIFF
--- a/app/Models/MiningArticle.php
+++ b/app/Models/MiningArticle.php
@@ -2,7 +2,9 @@
 
 namespace App\Models;
 
+use Database\Factories\MiningArticleFactory;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -19,6 +21,11 @@ use JonesRussell\NorthCloud\Models\Article;
 class MiningArticle extends Article
 {
     protected $table = 'mining_articles';
+
+    protected static function newFactory(): Factory
+    {
+        return MiningArticleFactory::new();
+    }
 
     protected $fillable = [
         'news_source_id',

--- a/database/factories/CommodityFactory.php
+++ b/database/factories/CommodityFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\Commodity;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 
 /** @extends Factory<Commodity> */
 class CommodityFactory extends Factory
@@ -17,7 +18,7 @@ class CommodityFactory extends Factory
 
         return [
             'name' => $name,
-            'slug' => strtolower($name),
+            'slug' => Str::slug($name),
             'symbol' => strtoupper(substr($name, 0, 2)),
         ];
     }

--- a/database/factories/CommodityFactory.php
+++ b/database/factories/CommodityFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Commodity;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<Commodity> */
+class CommodityFactory extends Factory
+{
+    protected $model = Commodity::class;
+
+    /** @return array<string, mixed> */
+    public function definition(): array
+    {
+        $name = fake()->unique()->word().' Metal';
+
+        return [
+            'name' => $name,
+            'slug' => strtolower($name),
+            'symbol' => strtoupper(substr($name, 0, 2)),
+        ];
+    }
+}

--- a/database/factories/DrillResultFactory.php
+++ b/database/factories/DrillResultFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DrillResult;
+use App\Models\MiningArticle;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<DrillResult> */
+class DrillResultFactory extends Factory
+{
+    protected $model = DrillResult::class;
+
+    /** @return array<string, mixed> */
+    public function definition(): array
+    {
+        return [
+            'mining_article_id' => MiningArticle::factory(),
+            'commodity_id' => null,
+            'company_id' => null,
+            'hole_id' => 'DDH-'.fake()->numerify('##-###'),
+            'intercept_m' => fake()->randomFloat(2, 1, 50),
+            'grade' => fake()->randomFloat(4, 0.1, 20),
+            'unit' => fake()->randomElement(['g/t', '%', 'ppm']),
+        ];
+    }
+}

--- a/database/factories/MiningArticleFactory.php
+++ b/database/factories/MiningArticleFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\MiningArticle;
+use App\Models\NewsSource;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<MiningArticle> */
+class MiningArticleFactory extends Factory
+{
+    protected $model = MiningArticle::class;
+
+    /** @return array<string, mixed> */
+    public function definition(): array
+    {
+        return [
+            'title' => fake()->sentence(),
+            'slug' => fake()->unique()->slug(),
+            'content' => fake()->paragraphs(3, true),
+            'excerpt' => fake()->sentence(),
+            'url' => fake()->url(),
+            'image_url' => fake()->imageUrl(),
+            'news_source_id' => NewsSource::factory(),
+            'published_at' => fake()->dateTimeBetween('-1 month'),
+            'external_id' => fake()->uuid(),
+        ];
+    }
+}

--- a/tests/Feature/Processing/MiningArticleProcessorDrillResultsTest.php
+++ b/tests/Feature/Processing/MiningArticleProcessorDrillResultsTest.php
@@ -109,29 +109,35 @@ it('handles unknown commodity gracefully', function () {
 });
 
 it('replaces drill results on re-ingestion', function () {
+    $processor = makeProcessor();
+
+    // First ingestion: create article with 1 drill result
     $payload = makePayload([
-        'title' => 'Unique Re-ingestion Test Article',
+        'title' => 'Re-ingestion Test Article',
         'drill_results' => [
             ['hole_id' => 'DDH-24-001', 'commodity' => 'gold', 'intercept_m' => 10.0, 'grade' => 2.0, 'unit' => 'g/t'],
         ],
     ]);
-
-    $processor = makeProcessor();
     $article = $processor->process($payload, null);
+    expect($article)->not->toBeNull();
     expect(DrillResult::where('mining_article_id', $article->id)->count())->toBe(1);
 
-    // Re-ingest with different drill results and different title to avoid dedup
-    $payload2 = makePayload([
-        'title' => 'Updated Re-ingestion Test Article',
+    // Directly call syncDrillResults on the same article with different results
+    $newData = [
         'drill_results' => [
             ['hole_id' => 'DDH-24-010', 'commodity' => 'gold', 'intercept_m' => 5.0, 'grade' => 1.0, 'unit' => 'g/t'],
             ['hole_id' => 'DDH-24-011', 'commodity' => 'gold', 'intercept_m' => 8.0, 'grade' => 3.0, 'unit' => 'g/t'],
         ],
-    ]);
+    ];
 
-    $article2 = $processor->process($payload2, null);
-    expect($article2)->not->toBeNull();
-    expect(DrillResult::where('mining_article_id', $article2->id)->count())->toBe(2);
+    // Use reflection to call protected syncDrillResults on the same article
+    $method = new \ReflectionMethod($processor, 'syncDrillResults');
+    $method->invoke($processor, $article, $newData);
+
+    // Old results should be replaced, not appended
+    expect(DrillResult::where('mining_article_id', $article->id)->count())->toBe(2);
+    expect(DrillResult::where('hole_id', 'DDH-24-001')->count())->toBe(0);
+    expect(DrillResult::where('hole_id', 'DDH-24-010')->count())->toBe(1);
 });
 
 it('stores various unit types correctly', function () {

--- a/tests/Feature/Processing/MiningArticleProcessorDrillResultsTest.php
+++ b/tests/Feature/Processing/MiningArticleProcessorDrillResultsTest.php
@@ -1,0 +1,155 @@
+<?php
+
+use App\Models\Commodity;
+use App\Models\DrillResult;
+use App\Processing\MiningArticleProcessor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function makeProcessor(): MiningArticleProcessor
+{
+    return app(MiningArticleProcessor::class);
+}
+
+function makePayload(array $overrides = []): array
+{
+    return array_merge([
+        'id' => fake()->uuid(),
+        'title' => 'Test Mining Corp Reports Drill Results',
+        'body' => 'Test article body about drill results.',
+        'source' => 'https://example.com/article',
+        'published_date' => now()->toIso8601String(),
+        'og_title' => 'Test Mining Corp Reports Drill Results',
+        'og_image' => 'https://example.com/image.jpg',
+        'quality_score' => 85,
+        'topics' => ['mining'],
+        'commodities' => ['gold'],
+        'companies' => [],
+        'categories' => ['Mining'],
+        'jurisdictions' => [],
+    ], $overrides);
+}
+
+it('stores drill results from payload', function () {
+    Commodity::factory()->create(['name' => 'Gold', 'slug' => 'gold']);
+
+    $payload = makePayload([
+        'drill_results' => [
+            ['hole_id' => 'DDH-24-001', 'commodity' => 'gold', 'intercept_m' => 12.5, 'grade' => 3.2, 'unit' => 'g/t'],
+            ['hole_id' => 'DDH-24-002', 'commodity' => 'gold', 'intercept_m' => 8.0, 'grade' => 1.8, 'unit' => 'g/t'],
+            ['hole_id' => 'DDH-24-003', 'commodity' => 'gold', 'intercept_m' => 5.5, 'grade' => 6.1, 'unit' => 'g/t'],
+        ],
+    ]);
+
+    $processor = makeProcessor();
+    $article = $processor->process($payload, null);
+
+    expect($article)->not->toBeNull();
+    expect(DrillResult::where('mining_article_id', $article->id)->count())->toBe(3);
+
+    $first = DrillResult::where('hole_id', 'DDH-24-001')->first();
+    expect($first->intercept_m)->toBe('12.50');
+    expect($first->grade)->toBe('3.2000');
+    expect($first->unit)->toBe('g/t');
+    expect($first->commodity_id)->not->toBeNull();
+});
+
+it('handles empty drill_results array', function () {
+    $payload = makePayload(['drill_results' => []]);
+
+    $processor = makeProcessor();
+    $article = $processor->process($payload, null);
+
+    expect($article)->not->toBeNull();
+    expect(DrillResult::where('mining_article_id', $article->id)->count())->toBe(0);
+});
+
+it('handles missing drill_results key', function () {
+    $payload = makePayload();
+    // Explicitly remove drill_results to test backward compat
+    unset($payload['drill_results']);
+
+    $processor = makeProcessor();
+    $article = $processor->process($payload, null);
+
+    expect($article)->not->toBeNull();
+    expect(DrillResult::where('mining_article_id', $article->id)->count())->toBe(0);
+});
+
+it('resolves commodity by slug', function () {
+    $gold = Commodity::factory()->create(['name' => 'Gold', 'slug' => 'gold']);
+
+    $payload = makePayload([
+        'drill_results' => [
+            ['hole_id' => 'DDH-24-001', 'commodity' => 'gold', 'intercept_m' => 10.0, 'grade' => 2.0, 'unit' => 'g/t'],
+        ],
+    ]);
+
+    $processor = makeProcessor();
+    $article = $processor->process($payload, null);
+
+    $result = DrillResult::where('mining_article_id', $article->id)->first();
+    expect($result->commodity_id)->toBe($gold->id);
+});
+
+it('handles unknown commodity gracefully', function () {
+    $payload = makePayload([
+        'drill_results' => [
+            ['hole_id' => 'DDH-24-001', 'commodity' => 'unobtainium', 'intercept_m' => 10.0, 'grade' => 2.0, 'unit' => 'g/t'],
+        ],
+    ]);
+
+    $processor = makeProcessor();
+    $article = $processor->process($payload, null);
+
+    $result = DrillResult::where('mining_article_id', $article->id)->first();
+    expect($result)->not->toBeNull();
+    expect($result->commodity_id)->toBeNull();
+});
+
+it('replaces drill results on re-ingestion', function () {
+    $payload = makePayload([
+        'title' => 'Unique Re-ingestion Test Article',
+        'drill_results' => [
+            ['hole_id' => 'DDH-24-001', 'commodity' => 'gold', 'intercept_m' => 10.0, 'grade' => 2.0, 'unit' => 'g/t'],
+        ],
+    ]);
+
+    $processor = makeProcessor();
+    $article = $processor->process($payload, null);
+    expect(DrillResult::where('mining_article_id', $article->id)->count())->toBe(1);
+
+    // Re-ingest with different drill results and different title to avoid dedup
+    $payload2 = makePayload([
+        'title' => 'Updated Re-ingestion Test Article',
+        'drill_results' => [
+            ['hole_id' => 'DDH-24-010', 'commodity' => 'gold', 'intercept_m' => 5.0, 'grade' => 1.0, 'unit' => 'g/t'],
+            ['hole_id' => 'DDH-24-011', 'commodity' => 'gold', 'intercept_m' => 8.0, 'grade' => 3.0, 'unit' => 'g/t'],
+        ],
+    ]);
+
+    $article2 = $processor->process($payload2, null);
+    expect($article2)->not->toBeNull();
+    expect(DrillResult::where('mining_article_id', $article2->id)->count())->toBe(2);
+});
+
+it('stores various unit types correctly', function () {
+    $payload = makePayload([
+        'drill_results' => [
+            ['hole_id' => 'DDH-24-001', 'commodity' => 'gold', 'intercept_m' => 10.0, 'grade' => 3.2, 'unit' => 'g/t'],
+            ['hole_id' => 'DDH-24-002', 'commodity' => 'copper', 'intercept_m' => 8.0, 'grade' => 1.5, 'unit' => '%'],
+            ['hole_id' => 'DDH-24-003', 'commodity' => 'gold', 'intercept_m' => 5.0, 'grade' => 850.0, 'unit' => 'ppm'],
+            ['hole_id' => 'DDH-24-004', 'commodity' => 'gold', 'intercept_m' => 12.0, 'grade' => 0.15, 'unit' => 'oz/t'],
+        ],
+    ]);
+
+    $processor = makeProcessor();
+    $article = $processor->process($payload, null);
+
+    $results = DrillResult::where('mining_article_id', $article->id)->get();
+    expect($results)->toHaveCount(4);
+
+    $units = $results->pluck('unit')->sort()->values()->all();
+    expect($units)->toBe(['%', 'g/t', 'oz/t', 'ppm']);
+});


### PR DESCRIPTION
## Summary
- Create MiningArticle, Commodity, and DrillResult model factories
- Add `newFactory()` override to MiningArticle model for vendor package compatibility
- 7 Pest integration tests for `syncDrillResults()`: happy path, empty array, missing key, commodity resolution, unknown commodity, re-ingestion replacement, unit variants

## Test Plan
- [x] All 7 tests pass (20 assertions)
- [x] Pint formatting passes
- [ ] Verify factories work in other test contexts

Refs: #9, #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)